### PR TITLE
Improve memory usage: switch from merge vcf to gather vcf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 movp.tar
 test/bigtestdata
+
+# github token
+github_token

--- a/conf/samples800_gsize500Mb.config
+++ b/conf/samples800_gsize500Mb.config
@@ -1,0 +1,154 @@
+// This config file was develop to work on setonix, ~800 samples, and a genome size of 500 Mb
+
+// Setonix specific constraints mainly represent the maximum number of inodes (files)
+// This in turns affects the gatk_chunksize parameter (which can be set at the end of this file).
+// The current chunk size achieves a balanace between number of inodes and memory usage for genotypeGVCF step
+// If you have a much larger genome you will need to increase the chunk size to limit the number of inodes
+// If that fails, I recommend running MOVP one chromosome at a time
+
+// Sample specific costraints mostly represent the memory needed for the multi sample genotypeGVCF step
+// If you have less than 800 samples, you can reduce the memory for multi sample steps (e.g., genotypeGVCF)
+// If you have more samples, (more than 1000?) you might struggle to get nodes with enough memory
+// If that's the case I suggest splitting by chromosome, and reducing the chunksize.
+      
+process {
+  scratch = true
+
+  queue = 'work'
+  cpus = 1
+  memory = 4.GB
+  time = '1h'
+  errorStrategy = 'retry'
+  maxRetries = 1
+
+  withName: 'bwa_index'{
+    time = '4h'
+    memory = 4.GB
+  }
+
+// QC
+// Used here entirely just for polyG trimming.  We will adapter trim later using MarkIlluminaAdapters assuming that this works better if data remains untrimmed at this point
+  withName: 'fastp' {
+    time = '4h'
+    memory = 8.GB
+    cpus = 4
+    ext.args = '--trim_poly_g  --dont_eval_duplication --disable_adapter_trimming'
+  }
+
+  withName: 'fastqc' {
+    time = '4h'
+  }
+
+// changed from 20.GB to 10.GB
+  withName: 'multiqc_fastqc'{
+    memory = 10.GB
+    time = '10h'
+  }
+
+  withName: 'multiqc_fastp'{
+    memory = 20.GB
+    time = '10h'
+  }
+
+// Read Preparation
+// changed from 6.GB to 10.GB
+  withName: 'markadapters'{
+    cpus = 2
+    memory = 10.GB
+  }
+
+  withName: 'fastq2ubam'{
+	  memory = { 30.GB * task.attempt }
+    cpus = 2
+  }
+
+// Mapping
+// changed from 50 to 20. failed for 1 sample, changed back to 30
+// NOTE: when I provided uneven numbers, it failed saying the requested amount/2 was not valid
+// if i provided 25 Gb, if failed saying that 12.5 was not valid
+  withName: 'bwa_mem_gatk'{
+    cpus = 4
+    memory = { 30.GB * task.attempt }
+    time = '23h'
+  }
+
+  withName: 'name_by_sample'{
+    memory = { 5.GB * task.attempt }
+  }
+
+  withName: 'samtools_merge'{
+    cpus = 1
+    memory = 20.GB
+    time = '10h'
+  }
+
+  withName: 'stat'{
+    cpus = 1
+    memory = 4.GB
+  }
+
+// Duplicate marking
+//
+  withName: 'gatk_mark_duplicates'{
+    memory = { 70.GB * task.attempt }
+    time = '23h'
+  }
+
+// variant calling and genotyping
+// changed haplo caller from 23 to 3 hours as it does not require that much
+// Note, that is with small (15 Mb) intervals, larger intervals will require more time
+  withName: 'gatk_haplotype_caller'{
+	cpus = 8
+	memory = { 8.GB * task.attempt }
+	time = '3h'
+  }
+
+  withName: 'gatk_genotypegvcfs'{
+  	memory = { 220.GB }
+	time = '23h'
+	scratch = true
+  }
+
+// changed from 80 to 100 GB, test
+// change from 23 to 12 hours for window of 14 Mb
+  withName: 'gatk_genomicsdb_import'{
+	memory = { 100.GB }
+	time = '12h'
+  }
+
+// changed from 8 to 1 cpus and from 120 to 220 GB
+// Above parameters were for merge vcfs and always failed.
+// current memory works for gather vcfs
+  withName: 'gatk_gathervcfs'{
+    memory = { 120.GB }
+    time = '23h'
+    cpus = 1
+  }
+
+  withName: 'mpileup_call'{
+    cpus = 1
+    memory = 10.GB
+    ext.args='-D -q 20 -Q 20 -a FORMAT/AD,FORMAT/ADF,FORMAT/ADR,FORMAT/DP,FORMAT/SP,FORMAT/SCR'
+    ext.callargs='-c -f GQ'
+  }
+
+  withName: 'freebayes'{
+    memory = { 20.GB * task.attempt }
+    time = '12h'
+    cpus = 2
+  }
+
+
+}
+
+
+// Increase chunksize for gatk
+// originally ran with 50,000,000, files were too large
+// Re ran with 5,000,000, produced too many files
+// Re ran with 20,000,000, too high mem usage for genotypeGVFs
+// Re ran with 20,000,000 and java_heap_fraction, and it ran for too long (> 23h, killed)
+// this avoids producing too many intermediate files
+params {
+    gatk_chunksize = 14500000
+    java_heap_fraction = 0.7
+}

--- a/conf/test.config
+++ b/conf/test.config
@@ -9,3 +9,7 @@ process {
   }
 
 }
+
+params {
+   java_heap_fraction = 0.7
+}

--- a/main.nf
+++ b/main.nf
@@ -3,7 +3,7 @@ nextflow.enable.dsl=2
 include { fastqc } from './modules/fastqc.nf'
 include { multiqc_fastqc; multiqc_fastp; multiqc_bams } from './modules/multiqc.nf'
 include { fastp } from './modules/fastp.nf'
-include { fastq2ubam; markadapters; bwa_mem_gatk; gatk4_createsequencedict; gatk4_createintervallist; gatk_scatterintervals; gatk_mark_duplicates; gatk_haplotype_caller; gatk_genomicsdb_import; gatk_genotypegvcfs; gatk_mergevcfs } from './modules/gatk.nf'
+include { fastq2ubam; markadapters; bwa_mem_gatk; gatk4_createsequencedict; gatk4_createintervallist; gatk_scatterintervals; gatk_mark_duplicates; gatk_haplotype_caller; gatk_genomicsdb_import; gatk_genotypegvcfs; gatk_gathervcfs } from './modules/gatk.nf'
 include { extract_umis } from './modules/fgbio.nf'
 include { bwa_index } from './modules/bwa.nf'
 include { sidx; faidx; flagstat; stat; idxstat; samtools_merge } from './modules/samtools.nf'
@@ -155,7 +155,10 @@ workflow call_variants {
 
       vcf_list = ch_gatk_vcfs.collectFile( name: "vcf.list", newLine:true){ id,f -> "$f" } | collect
 
-      gatk_mergevcfs(vcf_list,genome_dict)
+      gatk_gathervcfs(vcf_list)
+
+      // Switched from merge to gather, old code below
+      // gatk_mergevcf(vcf_list, genome_dict)
     }
 }
 

--- a/main.nf
+++ b/main.nf
@@ -8,7 +8,7 @@ include { extract_umis } from './modules/fgbio.nf'
 include { bwa_index } from './modules/bwa.nf'
 include { sidx; faidx; flagstat; stat; idxstat; samtools_merge } from './modules/samtools.nf'
 include { freebayes; fasta_generate_regions; freebayes_collect } from './modules/freebayes.nf'
-include { mpileup_call; mpileup_collect; fasta_generate_chrs; gatk_gathervcfs } from './modules/bcftools.nf'
+include { mpileup_call; mpileup_collect; fasta_generate_chrs; bcftools_concat } from './modules/bcftools.nf'
 include { name_by_sample } from './modules/util.nf'
 
 // Command line parameters
@@ -153,12 +153,13 @@ workflow call_variants {
 
       ch_gatk_vcfs = gatk_genotypegvcfs(ch_gdb,genome_fasta,genome_fai,genome_dict) 
 
-      vcf_list = ch_gatk_vcfs.collectFile( name: "vcf.list", newLine:true){ id,f -> "$f" } | collect
+      vcf_list = ch_gatk_vcfs.collectFile( name: "vcf.list", newLine:true){ id,f -> "$f" }
 
       gatk_gathervcfs(vcf_list)
 
       // Switched from merge to gather, old code below
       // gatk_mergevcf(vcf_list, genome_dict)
+      // Note, I also removed '| collect' from the end of vcf_list = ... line
     }
 }
 

--- a/main.nf
+++ b/main.nf
@@ -16,6 +16,9 @@ params.idt = false
 params.nocall = false
 params.samples = null
 params.bams = null
+// Default java_heap_fraction for genotypeGVCF
+// If not value is provided in custom config files, 0.8 is used
+params.java_heap_fraction = params.java_heap_fraction ?: 0.8
 
 
 println("IDT: ${params.idt}")

--- a/modules/bcftools.nf
+++ b/modules/bcftools.nf
@@ -66,7 +66,7 @@ process fasta_generate_chrs {
 
 }
 
-process gatk_gathervcfs {
+process bcftools_concat {
 
     publishDir "$params.outdir/gatk", mode: 'copy'
 

--- a/modules/gatk.nf
+++ b/modules/gatk.nf
@@ -285,15 +285,19 @@ process gatk_mergevcfs {
     path("gatk.vcf.gz.tbi"), emit: vcfi 
 
   script:
+    def args = task.ext.args ?: ''
+    def heap_gb = (task.memory.giga * params.java_heap_fraction) as int
 
     """
-    gatk --java-options "-Xmx${task.memory.giga}g -Xms${task.memory.giga}g" \
+    gatk --java-options "-Xmx{heap_gb}g -Xms{heap_gb}g" \
         MergeVcfs \
+        --MAX_RECORDS_IN_RAM 100000 \
         -I $vcflist \
         -D $dict \
         -O gatk.vcf.gz
     """
 }
 
-
-
+// Changed Xmx and Xms to 70% of tastk.memory.giga, to allow for memory outside java heap
+// Reduced task.memory.giga to 100, as it might allow for Garbage Control to work better
+// Added --MAX_RECORDS_IN_RAM 100000 (instead of default 500000) to try and address memory issue

--- a/modules/gatk.nf
+++ b/modules/gatk.nf
@@ -282,12 +282,8 @@ process gatk_gathervcfs {
     script:
       """
       # Construct GatherVcfs inputs string with ordered scattered vcfs
-      # sort ${vcflist} | xargs -I{} echo "-I {}" | tr '\\n' ' ' > inputs.txt
-      awk -F/ '{print $NF "\t" $0}' ${vcflist} \
-               | sort -k1,1V \
-               | cut -f2 \
-               | xargs -I{} echo "-I {}" | tr '\n' ' ' > inputs.txt
-
+      awk -F/ '{print \$NF "\t" \$0}' ${vcflist} | sort -k1,1V | cut -f2 | xargs -I{} echo "-I {}" | tr '\n' ' ' > inputs.txt
+      
       gatk --java-options "-Xmx${task.memory.giga}g -Xms${task.memory.giga}g" \
 	GatherVcfs \$(cat inputs.txt) \
 	-O gatk.vcf.gz

--- a/modules/gatk.nf
+++ b/modules/gatk.nf
@@ -285,19 +285,12 @@ process gatk_mergevcfs {
     path("gatk.vcf.gz.tbi"), emit: vcfi 
 
   script:
-    def args = task.ext.args ?: ''
-    def heap_gb = (task.memory.giga * params.java_heap_fraction) as int
 
     """
-    gatk --java-options "-Xmx{heap_gb}g -Xms{heap_gb}g" \
+    gatk --java-options "-Xmx{task.memory.giga}g -Xms{task.memory.giga}g" \
         MergeVcfs \
-        --MAX_RECORDS_IN_RAM 100000 \
         -I $vcflist \
         -D $dict \
         -O gatk.vcf.gz
     """
 }
-
-// Changed Xmx and Xms to 70% of tastk.memory.giga, to allow for memory outside java heap
-// Reduced task.memory.giga to 100, as it might allow for Garbage Control to work better
-// Added --MAX_RECORDS_IN_RAM 100000 (instead of default 500000) to try and address memory issue

--- a/modules/gatk.nf
+++ b/modules/gatk.nf
@@ -271,26 +271,48 @@ process gatk_genotypegvcfs {
 
 }
 
+// FIX -I $vcflist, need to expand the list
+process gatk_gathervcfs {
 
-process gatk_mergevcfs {
+    publishDir "$params.outdir/gatk", mode: 'copy'
 
-  publishDir "$params.outdir/gatk", mode: 'copy'
+    input:
+      path(vcflist)
 
-  input:
-    path(vcflist)
-    path(dict)
+    output:
+      path("gatk.vcf.gz"), emit: vcfz
+      path("gatk.vcf.gz.tbi"), emit: vcfi
 
-  output:
-    path("gatk.vcf.gz"), emit: vcfz
-    path("gatk.vcf.gz.tbi"), emit: vcfi 
+    script:
 
-  script:
-
-    """
-    gatk --java-options "-Xmx{task.memory.giga}g -Xms{task.memory.giga}g" \
-        MergeVcfs \
-        -I $vcflist \
-        -D $dict \
-        -O gatk.vcf.gz
-    """
+      """
+      gatk --java-options "-Xmx{task.memory.giga}g -Xms{task.memory.giga}g" \
+	GatherVcfs \
+	-I $vcflist \
+	-O gatk.vcf.gz
+      """
 }
+
+// Previously using picard's mergeVCF
+//process gatk_mergevcfs {
+//
+//  publishDir "$params.outdir/gatk", mode: 'copy'
+//
+//  input:
+//    path(vcflist)
+//    path(dict)
+//
+//  output:
+//    path("gatk.vcf.gz"), emit: vcfz
+//    path("gatk.vcf.gz.tbi"), emit: vcfi
+//
+//  script:
+//
+//    """
+//   gatk --java-options "-Xmx{task.memory.giga}g -Xms{task.memory.giga}g" \
+//        MergeVcfs \
+//        -I $vcflist \
+//        -D $dict \
+//        -O gatk.vcf.gz
+//    """
+//}

--- a/modules/gatk.nf
+++ b/modules/gatk.nf
@@ -259,7 +259,7 @@ process gatk_genotypegvcfs {
     def heap_gb = (task.memory.giga * params.java_heap_fraction) as int
 
     """
-    gatk --java-options "-Xmx${heap_gb}g -Xms${heap_gb}g -Xlog:gc*:file=gc.log" \
+    gatk --java-options "-Xmx${heap_gb}g -Xms${heap_gb}g" \
         GenotypeGVCFs \
         -R $genome \
         -O ${regionid}.vcf.gz \

--- a/modules/gatk.nf
+++ b/modules/gatk.nf
@@ -281,8 +281,12 @@ process gatk_gathervcfs {
 
     script:
       """
-      # Construct GatherVcfs inputs string
-      sort ${vcflist} | xargs -I{} echo "-I {}" | tr '\\n' ' ' > inputs.txt
+      # Construct GatherVcfs inputs string with ordered scattered vcfs
+      # sort ${vcflist} | xargs -I{} echo "-I {}" | tr '\\n' ' ' > inputs.txt
+      awk -F/ '{print $NF "\t" $0}' ${vcflist} \
+               | sort -k1,1V \
+               | cut -f2 \
+               | xargs -I{} echo "-I {}" | tr '\n' ' ' > inputs.txt
 
       gatk --java-options "-Xmx${task.memory.giga}g -Xms${task.memory.giga}g" \
 	GatherVcfs \$(cat inputs.txt) \

--- a/modules/gatk.nf
+++ b/modules/gatk.nf
@@ -256,9 +256,10 @@ process gatk_genotypegvcfs {
 
     script:
     def args = task.ext.args ?: ''
+    def heap_gb = (task.memory.giga * params.java_heap_fraction) as int
 
     """
-    gatk --java-options "-Xmx${task.memory.giga}g -Xms${task.memory.giga}g" \
+    gatk --java-options "-Xmx${heap_gb}g -Xms${heap_gb}g -Xlog:gc*:file=gc.log" \
         GenotypeGVCFs \
         -R $genome \
         -O ${regionid}.vcf.gz \


### PR DESCRIPTION
Feature to switch from using Merge VCF to using Gather VCF at the end of the GATK HaplotypeCaller pipeline.

**Rationale**: Previously, the workflow was breaking for large sample sizes (~700) as gatherVCF ended up using too much memory, even with 1 single core being used. Reducing the interval further was not feasible as it produced too many files reaching the inode limit on setonix.

**Background**: GatherVcfs works on adjacent, non-overlapping VCFs that contain the same individuals in the same order. Input VCF files need to be in genomic order according to the genome.dict.

**Testing**: The new feature has been tested both with the `test` config and on a subset of 10 A.kenti samples. It still needs to be tested on a large (~700 individuals) dataset.

**List of changes**:
- renamed `process gatk_mergevcfs` to `process gatk_gathervcfs`
- swapped gatk MergeVcfs to gatk GatherVcfs
- added an awk script that orders scattered vcfs from genotypeVCFs based on their filename
- added a tabix step as GatherVcfs does not automatically index the resulting vcf file
- removed the `path(dict)` from the list of inputs as it is not required by gatherVcfs
- changed how vcf_list is being produced within `main.nf` to make sorting easier (i.e., removed the ` | collect` step
- renamed gatk_mergevcfs to gatk_gathervcfs within `main.nf`
- changed include statements within `main.nf` accordingly